### PR TITLE
deletion related perf improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ Table of Contents
 	* [Test 1](#test-1)
 	* [Test 4](#test-4)
 
+## Local Modifications
+
+This fork of pudge improves the efficiency of deletions for databases with
+large numbers of keys. It also provides a compaction API call to remove
+deleted keys and values, and also 'orphaned' entries in the value file that
+are no longer used.
+
 ## Description
 
 Package pudge is a fast and simple key/value store written using Go's standard library.


### PR DESCRIPTION
This PR dramatically improves the performance of multiple deletions in a database with a large number of keys. The original previous code would resort the database before every deletion, the changes are simply to sort once and then delete multiple keys.
An API call is also added to 'compact' both the key and value files to remove deleted keys and entries, and also entries that have 'outgrown' their original size in the value file (an existing value will be overwritten if the new value is the same size or smaller, or appended otherwise).